### PR TITLE
Change size directly from menubar

### DIFF
--- a/SpotifyLyricsInMenubar/SpotifyLyricsInMenubarApp.swift
+++ b/SpotifyLyricsInMenubar/SpotifyLyricsInMenubarApp.swift
@@ -71,6 +71,18 @@ struct SpotifyLyricsInMenubarApp: App {
             }
             .disabled(!hasOnboarded)
             Divider()
+            Text("Menubar Size is \(truncationLength)")
+            if truncationLength != 60 {
+                Button("Increase Size to \(truncationLength+10) ") {
+                    truncationLength = truncationLength + 10
+                }
+            }
+            if truncationLength != 30 {
+                Button("Decrease Size to \(truncationLength-10)") {
+                    truncationLength = truncationLength - 10
+                }
+            }
+            Divider()
             Button("Settings") {
                 NSApplication.shared.activate(ignoringOtherApps: true)
                 openWindow(id: "onboarding")


### PR DESCRIPTION
So that user doesn't have to go through settings page. Downside is user may be tempted to fidget with it causing lyric fever to disappear on no menubar space. Wish macOS had a way to let me know how much menubar space is available. what a trash API. 