### PR TITLE
OnboardingWindow: Manually check for Spotify running before querying automation status

### DIFF
--- a/SpotifyLyricsInMenubar/OnboardingWindow.swift
+++ b/SpotifyLyricsInMenubar/OnboardingWindow.swift
@@ -98,6 +98,14 @@ struct OnboardingWindow: View {
                             Button("Give Spotify Permissions") {
                                 
                                 let target = NSAppleEventDescriptor(bundleIdentifier: "com.spotify.client")
+                                // Can cause a freeze if app we're querying for isn't open
+                                // See: https://forums.developer.apple.com/forums/thread/666528
+                                guard let _ = NSRunningApplication.runningApplications(withBundleIdentifier: "com.spotify.client").first else {
+                                    withAnimation {
+                                        errorMessage = "Please Open Spotify First!"
+                                    }
+                                    return
+                                }
                                 let status = AEDeterminePermissionToAutomateTarget(target.aeDesc, typeWildCard, typeWildCard, true)
                                 switch status {
                                     case -600:


### PR DESCRIPTION
Fixes a rare freeze